### PR TITLE
Output the package.js with non-deprecated syntax.

### DIFF
--- a/testProxyPackage/sync.js
+++ b/testProxyPackage/sync.js
@@ -121,7 +121,7 @@ Velocity.ProxyPackageSync = {};
       '\t' + 'debugOnly: true' + '\n' +
       '});' + '\n' +
       '\n' +
-      'Package.on_use(function (api) {' + '\n' +
+      'Package.onUse(function (api) {' + '\n' +
       '\t' + 'api.use("coffeescript", ["client", "server"]);' + '\n' +
       _getFixtureFiles() +
       _getTestFiles() +


### PR DESCRIPTION
Remove the on_use in favor of the newer onUse call for package.js.
